### PR TITLE
Add flow typecheck

### DIFF
--- a/src/WhereWereWe.UI/.babelrc
+++ b/src/WhereWereWe.UI/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["react", "es2015"]
+    "presets": ["react", "es2015"],
+    "plugins": ["transform-flow-strip-types"]
 }

--- a/src/WhereWereWe.UI/.eslintrc.json
+++ b/src/WhereWereWe.UI/.eslintrc.json
@@ -8,6 +8,7 @@
         "eslint:recommended",
         "plugin:react/recommended"
     ],
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaFeatures": {
             "experimentalObjectRestSpread": true,

--- a/src/WhereWereWe.UI/.flowconfig
+++ b/src/WhereWereWe.UI/.flowconfig
@@ -1,0 +1,2 @@
+[ignore]
+<PROJECT_ROOT>/node_modules/.*

--- a/src/WhereWereWe.UI/package.json
+++ b/src/WhereWereWe.UI/package.json
@@ -14,18 +14,24 @@
     "babel-preset-react": "~6.16.0",
     "babel-loader": "~6.2.7",
     "babel-cli": "~6.18.0",
+    "babel-eslint": "~7.1.0",
+    "babel-plugin-transform-flow-strip-types": "~6.18.0",
     "eslint": "~3.9.1",
     "eslint-plugin-react": "~6.5.0",
     "eslint-watch": "~2.1.14",
     "express": "~4.14.0",
     "npm-run-all": "~3.1.1",
     "path": "~0.12.7",
-    "open": "~0.0.5"
+    "open": "~0.0.5",
+    "flow-bin": "^0.34.0",
+    "nodemon": "~1.11.0"
   },
   "scripts": {
-    "start": "npm-run-all --parallel run:debug lint:watch",
+    "start": "npm-run-all --parallel run:debug lint:watch flowcheck:watch",
     "run:debug": "babel-node tools/server.dev.js",
     "lint": "node_modules/.bin/esw *.js src tools --color",
-    "lint:watch": "npm run lint -- --watch"
+    "lint:watch": "npm run lint -- --watch",
+    "flowcheck": "flow check --color always || exit 0",
+    "flowcheck:watch": "nodemon -e js --watch src -x \"npm run-script flowcheck\""
   }
 }


### PR DESCRIPTION
I didn't like the way eslint-plugin-flowtype-errors interferes with my Visual Studio Code flow support and omits the context of the errors.
Simple watch flow proved somewhat fragile, leaving multiple instances of the flow server running.
Scripting full flow check repeatedly via nodemon is admitably quite slow, but only reliable approach I was able to find.